### PR TITLE
Sdas-2415 enable docker

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: Restart Shorewall Service
-  service: name={{ shorewall_service }} state=restarted 
+  service: name={{ shorewall_service }} state=restarted
+  when:
+    - shorewall_enabled is defined
+    - shorewall_enabled == 'Yes'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,3 +96,6 @@
 # Enable Shorewall server
 - name: Start the  Shorewall service
   service: name={{ shorewall_service }} state=started enabled=yes
+  when:
+    - shorewall_enabled is defined
+    - shorewall_enabled == 'Yes' 

--- a/templates/shorewall.conf.j2
+++ b/templates/shorewall.conf.j2
@@ -135,6 +135,10 @@ DELETE_THEN_ADD=Yes
 
 DETECT_DNAT_IPADDRS=No
 
+{% if shorewall_docker_fix_needed is defined and not shorewall_docker_fix_needed %}
+DOCKER=Yes
+{% endif %}
+
 DONT_LOAD=
 
 DYNAMIC_BLACKLIST=Yes


### PR DESCRIPTION
http://shorewall.org/Docker.html#idm20

Shorewall 5.0.6 and Later
Beginning with Shorewall 5.0.6, Shorewall has native support for simple Docker configurations. This support is enabled by setting DOCKER=Yes in shorewall.conf. With this setting, the generated script saves the Docker-created ruleset before executing a stop, start, restart or reload operation and restores those rules along with the Shorewall-generated ruleset.

This support assumes that the default Docker bridge (docker0) is being used. It is recommended that this bridge be defined to Shorewall in shorewall-interfaces(8). As shown below, you can control inter-container communication using the bridge and routeback options. If docker0 is not defined to Shorewall, then Shorewall will save and restore the FORWARD chain rules involving that interface.